### PR TITLE
Fixed gather step not generating correct information

### DIFF
--- a/gladier_kanzus/tools/gather_data.py
+++ b/gladier_kanzus/tools/gather_data.py
@@ -11,6 +11,7 @@ def ssx_gather_data(**data):
     trigger_name = data['trigger_name']
     processing_dir = data['proc_dir']
     upload_dir = data['upload_dir']
+    tar_input = data['tar_input']
 
     sample_metadata = trigger_name.split('/')[-4:]
     assert len(sample_metadata) == 4 and trigger_name.endswith('cbf'), (
@@ -64,10 +65,11 @@ def ssx_gather_data(**data):
         'total_number_of_int_files': len(int_indices)
     }
 
-    # Create a zip of all the int files
-    with ZipFile(os.path.join(upload_dir, 'ints.zip'), 'w') as zipObj:
-        for int_filename in int_filenames:
-            zipObj.write(os.path.join(processing_dir, int_filename))
+    # Move int files to the upload dir.
+    os.makedirs(tar_input, mode=0o775, exist_ok=True)
+    for int_filename in int_filenames:
+        shutil.copyfile(os.path.join(processing_dir, int_filename),
+                        os.path.join(tar_input, int_filename))
 
     # Fetch beamline metadata
     with open(beamline_file, 'r') as fp:
@@ -116,6 +118,7 @@ class SSXGatherData(GladierBaseTool):
 
     required_input = [
         'trigger_name',
+        'tar_input',
         'proc_dir',
         'upload_dir',
         'funcx_endpoint_non_compute',

--- a/gladier_kanzus/tools/gather_data.py
+++ b/gladier_kanzus/tools/gather_data.py
@@ -72,32 +72,36 @@ def ssx_gather_data(**data):
     # Fetch beamline metadata
     with open(beamline_file, 'r') as fp:
         beamline_metadata = json.load(fp)
-    protein = beamline_metadata.get('user_input', {}).get('prot_name') or protein
+    user_input = beamline_metadata.get('user_input', {})
+    protein = user_input.get('protein_name', protein)
 
-    metadata = {
-        'processing_dir': processing_dir,
-        'upload_dir': upload_dir,
-        'plot_filename': os.path.join(upload_dir, 'composite.png'),
-        'int_indices': sorted(int_indices),
-        'metadata': {
-            'chip': exp_name,
-            'experiment_number': exp_number,
-            'run_name': run_name,
-            'protein': protein,
-            'trigger_name': trigger_name,
-            'batch_info': batch_info,
+    # Update any metadata in the pilot 'metadata' key
+    metadata = data['pilot'].get('metadata', {})
+    metadata.update(beamline_metadata)
+    metadata.update({
+        'chip': exp_name,
+        'experiment_number': exp_number,
+        'run_name': run_name,
+        'protein': protein,
+        'trigger_name': trigger_name,
+        'batch_info': batch_info,
+    })
+    data['pilot']['metadata'] = metadata
+
+    return {
+        'pilot': data['pilot'],
+        'plot': {
+            'plot_filename': os.path.join(upload_dir, 'composite.png'),
+            'int_indices': sorted(int_indices),
+            'x_num_steps': user_input.get('x_num_steps', 0),
+            'y_num_steps': user_input.get('y_num_steps', 0),
         }
     }
-    metadata['metadata'].update(beamline_metadata)
-    metadata['metadata'].update(data.get('metadata', {}))
-
-    pilot = data['pilot']
-    pilot['metadata'] = metadata
-    pilot['groups'] = pilot.get('groups', [])
-    return pilot
 
 
-@generate_flow_definition
+@generate_flow_definition(modifiers={
+    'ssx_gather_data': {'endpoint': 'funcx_endpoint_non_compute'}
+})
 class SSXGatherData(GladierBaseTool):
 
     flow_input = {

--- a/gladier_kanzus/tools/plot.py
+++ b/gladier_kanzus/tools/plot.py
@@ -2,30 +2,31 @@ from typing import List
 from gladier import GladierBaseTool, generate_flow_definition
 
 
-def ssx_plot(xdim=0, ydim=0, int_indices=[], plot_filename='composite.png'):
+def ssx_plot(x_num_steps=0, y_num_steps=0, int_indices=[], plot_filename='composite.png'):
     """
     Plot the current list of ints so far. Data requires the following keys
-        * xdim (int) X dimension for the plot
-        * ydim (int) Y dimension for the plot
+        * x_num_steps (int) X dimension for the plot
+        * y_num_steps (int) Y dimension for the plot
         * int_indices (list of ints) list of int 'hits' to light up on the plot
         * plot_name (path) full filename to save the plot
     """
     import numpy as np
     from matplotlib import pyplot as plt
 
-    lattice_counts = np.zeros(xdim*ydim, dtype=np.dtype(int))
+    lattice_counts = np.zeros(x_num_steps*y_num_steps, dtype=np.dtype(int))
     for index in int_indices:
         lattice_counts[index] += 1
-    lattice_counts = lattice_counts.reshape((ydim, xdim))
+    lattice_counts = lattice_counts.reshape((y_num_steps, x_num_steps))
     # reverse the order of alternating rows
     lattice_counts[1::2, :] = lattice_counts[1::2, ::-1]
 
     # plot the lattice counts
-    plt.figure(figsize=(xdim/10., ydim/10.))
+    plt.figure(figsize=(x_num_steps/10., y_num_steps/10.))
     plt.axes([0, 0, 1, 1])  # Make the plot occupy the whole canvas
     plt.axis('off')
     plt.imshow(lattice_counts, cmap='hot', interpolation=None, vmax=4)
     plt.savefig(plot_filename)
+    return plot_filename
 
 
 @generate_flow_definition(modifiers={

--- a/gladier_kanzus/tools/plot.py
+++ b/gladier_kanzus/tools/plot.py
@@ -2,7 +2,7 @@ from typing import List
 from gladier import GladierBaseTool, generate_flow_definition
 
 
-def ssx_plot(xdim, ydim, int_indices, plot_filename):
+def ssx_plot(xdim=0, ydim=0, int_indices=[], plot_filename='composite.png'):
     """
     Plot the current list of ints so far. Data requires the following keys
         * xdim (int) X dimension for the plot
@@ -28,13 +28,15 @@ def ssx_plot(xdim, ydim, int_indices, plot_filename):
     plt.savefig(plot_filename)
 
 
-@generate_flow_definition
+@generate_flow_definition(modifiers={
+    'ssx_plot': {'endpoint': 'funcx_endpoint_non_compute'}
+})
 class SSXPlot(GladierBaseTool):
 
     flow_input = {}
 
     required_input = [
-        'funcx_endpoint_compute',
+        'funcx_endpoint_non_compute',
     ]
 
     funcx_functions = [

--- a/scripts/gladier_dev.py
+++ b/scripts/gladier_dev.py
@@ -136,21 +136,9 @@ class TransferClient(GladierBaseClient):
 
 @generate_flow_definition(modifiers={
     'funcx_create_phil': {'endpoint': 'funcx_endpoint_non_compute'},
-    'ssx_gather_data': {'endpoint': 'funcx_endpoint_non_compute'},
-    'ssx_plot': {
-        'payload': {
-            'xdim.$': '$.SsxGatherData.details.result[0].metadata.user_input.x_num_steps',
-            'ydim.$': '$.SsxGatherData.details.result[0].metadata.user_input.y_num_steps',
-            'int_indices.$': '$.SsxGatherData.details.result[0].int_indices',
-            'plot_filename.$': '$.SsxGatherData.details.result[0].plot_filename',
-         },
-        'endpoint': 'funcx_endpoint_non_compute',
-
-    },
-    'publish_gather_metadata': {
-        'WaitTime': 120,
-        'payload': '$.SsxGatherData.details.result[0]',
-    },
+    # SSXGatherData produces both 'plot' data for plots and 'pilot' metadata for ingesting into search
+    'ssx_plot': {'payload': '$.SsxGatherData.details.result[0].plot'},
+    'publish_gather_metadata': {'WaitTime': 120, 'payload': '$.SsxGatherData.details.result[0].pilot'},
 })
 class StillsClient(GladierBaseClient):
     gladier_tools = [
@@ -160,7 +148,7 @@ class StillsClient(GladierBaseClient):
         'gladier_kanzus.tools.SSXGatherData',
         'gladier_kanzus.tools.TransferProc',
         'gladier_kanzus.tools.SSXPlot',
-        'gladier_kanzus.tools.SSXPublish',
+        'gladier_tools.publish.Publish',
         'gladier_kanzus.tools.TransferImage',
     ]
 

--- a/scripts/plot_and_publish.py
+++ b/scripts/plot_and_publish.py
@@ -1,9 +1,11 @@
 from pprint import pprint
+import pathlib
 from gladier import GladierBaseClient, generate_flow_definition
 import gladier_kanzus.logging  # noqa
 
 
 @generate_flow_definition(modifiers={
+    'tar': {'endpoint': 'funcx_endpoint_non_compute'},
     'ssx_plot': {'payload': '$.SsxGatherData.details.result[0].plot'},
     'publish_gather_metadata': {'WaitTime': 120, 'payload': '$.SsxGatherData.details.result[0].pilot'},
 })
@@ -13,6 +15,7 @@ class SSXPlotAndPublish(GladierBaseClient):
         # 'gladier_kanzus.tools.CreatePhil',
         # 'gladier_kanzus.tools.DialsStills',
         'gladier_kanzus.tools.gather_data.SSXGatherData',
+        'gladier_tools.posix.tar.Tar',
         'gladier_kanzus.tools.plot.SSXPlot',
         'gladier_tools.publish.Publish',
     ]
@@ -26,6 +29,8 @@ if __name__ == '__main__':
             'trigger_name': '/projects/APSDataAnalysis/nick/SSX/S13/LYSO/A/Avalon_13_00025.cbf',
             'proc_dir': '/projects/APSDataAnalysis/nick/SSX/S13/LYSO/A/a_processing',
             'upload_dir': upload_dir,
+            'tar_input': str(pathlib.Path(upload_dir).parent / 'ints'),
+            'tar_output': str(pathlib.Path(upload_dir) / 'ints.tar.gz'),
 
             'pilot': {
                 # This is the directory which will be published to petrel

--- a/scripts/plot_and_publish.py
+++ b/scripts/plot_and_publish.py
@@ -4,18 +4,8 @@ import gladier_kanzus.logging  # noqa
 
 
 @generate_flow_definition(modifiers={
-    'ssx_gather_data': {'endpoint': 'funcx_endpoint_non_compute'},
-    'ssx_plot': {'payload': {
-            'xdim.$': '$.SsxGatherData.details.result[0].metadata.user_input.x_num_steps',
-            'ydim.$': '$.SsxGatherData.details.result[0].metadata.user_input.y_num_steps',
-            'int_indices.$': '$.SsxGatherData.details.result[0].int_indices',
-            'plot_filename.$': '$.SsxGatherData.details.result[0].plot_filename',
-         }
-    },
-    'publish_gather_metadata': {
-        'WaitTime': 120,
-        'payload': '$.SsxGatherData.details.result[0]',
-},
+    'ssx_plot': {'payload': '$.SsxGatherData.details.result[0].plot'},
+    'publish_gather_metadata': {'WaitTime': 120, 'payload': '$.SsxGatherData.details.result[0].pilot'},
 })
 class SSXPlotAndPublish(GladierBaseClient):
     gladier_tools = [


### PR DESCRIPTION
Previously the gather step only returned metadata that was useful for plotting, and the metadata generated for search was simply lost. Now it returns both metadata for search under a 'pilot' key and plotting information under a 'plot' key. Simplified modifiers route the payloads to both tools. 